### PR TITLE
ci: Cancel runs when new code is pushed to the same branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,12 @@ on:
     branches:
       - '**'
 
+# On any PR branch, cancel active workflows if new code is pushed to the same head_ref (i.e., the same PR).
+# Fallback to github.run_id for non-PRs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
CI should only spend time on latest ref.

Also, you can integrate the smaller changes with a release cadence instead of making a new release for every new contribution. @parksb  