### PR TITLE
feat: Enforce consistent style in Rust code with rustfmt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,3 +45,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           projectPath: src-tauri
+
+  fmt:
+    runs-on: ubuntu-latest
+    name: Run cargo fmt on stable
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: cargo fmt --check
+        run: cargo fmt --check
+        working-directory: src-tauri

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,9 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: install pnpm
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install stable
+      - name: Install Rust stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt


### PR DESCRIPTION
>[!WARNING]
>DO NOT MERGE BEFORE PR 28

This PR ensures we format all Rust Code on commits or PR. Previously, we did not have a mechanism to make sure Rust code follows conventional style guidelines.

Part of the effort for https://github.com/collie-reader/collie/issues/26